### PR TITLE
Utilize maven-compiler-plugin in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,16 @@
                     </links>
                 </configuration>
             </plugin>
-			-->
+            -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <compilerArgument></compilerArgument>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This prevents any weirdness with OpenJDK systems and... ya' know... specificity.