### PR TITLE
Add Predefined Formatters to TimeTag.format

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/core/TimeTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/TimeTag.java
@@ -20,6 +20,7 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
+import java.lang.reflect.Field;
 
 public class TimeTag implements ObjectTag, Adjustable, FlaggableObject {
 
@@ -755,10 +756,18 @@ public class TimeTag implements ObjectTag, Adjustable, FlaggableObject {
     }
 
     public String format(String formatText) {
+        DateTimeFormatter format;
+
         if (formatText == null) {
-            formatText = "yyyy/MM/dd HH:mm:ss";
+            format = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+        } else {
+            try {
+                format = DateTimeFormatter.getClass().getField(formatText.toUpperCase()).get(DateTimeFormatter);
+            } catch (NoSuchFieldException e) {
+                format = DateTimeFormatter.ofPattern(formatText);
+            }
         }
-        DateTimeFormatter format = DateTimeFormatter.ofPattern(formatText);
+
         return instant.format(format);
     }
 


### PR DESCRIPTION
Now, before assuming that formatText is a valid pattern, we check to see if formatText is a valid formatter instead. We get the field, then attempt to get the value from that field. If formatText isn't a valid formatter, then it will throw a noSuchField exception before it gets to the .get() (based on my very limited understanding of java lol). If we catch the exception, we instead set the format to formatText, which was basically the original behaviour.