### PR TITLE
CoreUtilities.parseIndex added and applied to ListTag.get

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
@@ -1419,22 +1419,18 @@ public class ListTag implements List<String>, ObjectTag {
                 if (indices.size() > 1) {
                     ListTag results = new ListTag();
                     for (String index : indices) {
-                        int ind = Integer.parseInt(index);
-                        if (ind > 0 && ind <= object.size()) {
-                            results.add(object.get(ind - 1));
+                        int ind = CoreUtilities.parseIndex(indices, index);
+                        if (ind >= 0) {
+                            results.add(object.get(ind));
                         }
                     }
                     return results;
                 }
                 if (indices.size() > 0) {
-                    int index = Integer.parseInt(indices.get(0)) - 1;
-                    if (index >= object.size()) {
-                        attribute.echoError("Invalid list.get index '" + (index + 1) + "' ... list is only " + object.size() + " long.");
-                        return null;
-                    }
+                    int index = CoreUtilities.parseIndex(indices, indices.get(0));
                     if (index < 0) {
-                        attribute.echoError("Invalid list.get index '" + (index + 1) + "' ... must be at least 1.");
-                        index = 0;
+                        attribute.echoError("Invalid list.get index '" + (index + 1));
+                        return null;
                     }
 
                     // <--[tag]
@@ -1447,18 +1443,10 @@ public class ListTag implements List<String>, ObjectTag {
                     // For example: .get[3].to[last] on a list of "one|two|three|four" will return "three|four".
                     // -->
                     if (attribute.startsWith("to", 2) && attribute.hasContext(2)) {
-                        int index2;
-                        if (CoreUtilities.equalsIgnoreCase(attribute.getContext(2), "last")) {
-                            index2 = object.size() - 1;
-                        }
-                        else {
-                            index2 = attribute.getIntContext(2) - 1;
-                        }
-                        if (index2 >= object.size()) {
-                            index2 = object.size() - 1;
-                        }
-                        if (index2 < 0) {
-                            index2 = 0;
+                        int index2 = CoreUtilities.parseIndex(indices, attribute.getContext(2));
+                        if (index2 < 0 || index2 < index) {
+                            attribute.echoError("Invalid list.get.to index '" + (index2 + 1));
+                            return null;
                         }
                         ListTag newList = new ListTag();
                         for (int i = index; i <= index2; i++) {

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
@@ -1407,7 +1407,7 @@ public class ListTag implements List<String>, ObjectTag {
         // Specify more than one index to get a list of results.
         // .get[first] and .get[last] can be used to get the first and last elements of the list.
         // A negative index will count from the end of the list.
-        // So .get[-1] on a list of "one|two|three" will return "two".
+        // So .get[-2] on a list of "one|two|three" will return "two".
         // -->
         TagRunnable.ObjectInterface<ListTag, ObjectTag> getRunnable = (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -1449,7 +1449,7 @@ public class ListTag implements List<String>, ObjectTag {
                     // Use "last" as the 'to' index to automatically get all of the list starting at the first index.
                     // For example: .get[3].to[last] on a list of "one|two|three|four" will return "three|four".
                     // Negative indices can be used for the 'get' index as well as the 'to', counting from the end of the list.
-                    // For example: .get[-1].to[last] on a list of "one|two|three|four" will return "three|four".
+                    // For example: .get[-2].to[-1] on a list of "one|two|three|four" will return "three|four".
                     // -->
                     if (attribute.startsWith("to", 2) && attribute.hasContext(2)) {
                         int index2 = CoreUtilities.parseIndex(object.objectForms, attribute.getContext(2));

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
@@ -1422,7 +1422,7 @@ public class ListTag implements List<String>, ObjectTag {
                 if (indices.size() > 1) {
                     ListTag results = new ListTag();
                     for (String index : indices) {
-                        int ind = CoreUtilities.parseIndex(indices, index);
+                        int ind = CoreUtilities.parseIndex(object.objectForms, index);
                         if (ind >= 0) {
                             results.add(object.get(ind));
                         } else {
@@ -1432,7 +1432,7 @@ public class ListTag implements List<String>, ObjectTag {
                     return results;
                 }
                 if (indices.size() > 0) {
-                    int index = CoreUtilities.parseIndex(indices, indices.get(0));
+                    int index = CoreUtilities.parseIndex(object.objectForms, indices.get(0));
                     if (index < 0) {
                         attribute.echoError("Invalid list.get index '" + (index + 1));
                         return null;
@@ -1450,7 +1450,7 @@ public class ListTag implements List<String>, ObjectTag {
                     // For example: .get[-1].to[last] on a list of "one|two|three|four" will return "three|four".
                     // -->
                     if (attribute.startsWith("to", 2) && attribute.hasContext(2)) {
-                        int index2 = CoreUtilities.parseIndex(indices, attribute.getContext(2));
+                        int index2 = CoreUtilities.parseIndex(object.objectForms, attribute.getContext(2));
                         if (index2 < 0 || index2 < index) {
                             attribute.echoError("Invalid list.get.to index '" + (index2 + 1));
                             return null;

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
@@ -1404,6 +1404,9 @@ public class ListTag implements List<String>, ObjectTag {
         // Returns an element of the value specified by the supplied context.
         // For example: .get[1] on a list of "one|two" will return "one", and .get[2] will return "two"
         // Specify more than one index to get a list of results.
+        // .get[first] and .get[last] can be used to get the first and last elements of the list.
+        // A negative index will count from the end of the list.
+        // So .get[-1] on a list of "one|two|three" will return "two".
         // -->
         TagRunnable.ObjectInterface<ListTag, ObjectTag> getRunnable = (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -1443,6 +1446,8 @@ public class ListTag implements List<String>, ObjectTag {
                     // For example: .get[1].to[3] on a list of "one|two|three|four" will return "one|two|three".
                     // Use "last" as the 'to' index to automatically get all of the list starting at the first index.
                     // For example: .get[3].to[last] on a list of "one|two|three|four" will return "three|four".
+                    // Negative indices can be used for the 'get' index as well as the 'to', counting from the end of the list.
+                    // For example: .get[-1].to[last] on a list of "one|two|three|four" will return "three|four".
                     // -->
                     if (attribute.startsWith("to", 2) && attribute.hasContext(2)) {
                         int index2 = CoreUtilities.parseIndex(indices, attribute.getContext(2));

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
@@ -1426,7 +1426,8 @@ public class ListTag implements List<String>, ObjectTag {
                         int ind = CoreUtilities.parseIndex(object.objectForms, index);
                         if (ind >= 0) {
                             results.add(object.get(ind));
-                        } else {
+                        }
+                        else {
                             attribute.echoError("Invalid index '" + index + "'.");
                         }
                     }
@@ -1435,7 +1436,7 @@ public class ListTag implements List<String>, ObjectTag {
                 if (indices.size() > 0) {
                     int index = CoreUtilities.parseIndex(object.objectForms, indices.get(0));
                     if (index < 0) {
-                        attribute.echoError("Invalid list.get index '" + (index + 1));
+                        attribute.echoError("Invalid list.get index '" + (index + 1) + "'.");
                         return null;
                     }
 
@@ -1452,8 +1453,8 @@ public class ListTag implements List<String>, ObjectTag {
                     // -->
                     if (attribute.startsWith("to", 2) && attribute.hasContext(2)) {
                         int index2 = CoreUtilities.parseIndex(object.objectForms, attribute.getContext(2));
-                        if (index2 < 0 || index2 < index) {
-                            attribute.echoError("Invalid list.get.to index '" + (index2 + 1));
+                        if (index2 < 0) {
+                            attribute.echoError("Invalid list.get.to index of '" + (index2 + 1) + "'.");
                             return null;
                         }
                         ListTag newList = new ListTag();

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
@@ -1422,6 +1422,8 @@ public class ListTag implements List<String>, ObjectTag {
                         int ind = CoreUtilities.parseIndex(indices, index);
                         if (ind >= 0) {
                             results.add(object.get(ind));
+                        } else {
+                            attribute.echoError("Invalid index '" + index + "'.");
                         }
                     }
                     return results;

--- a/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
@@ -709,6 +709,30 @@ public class CoreUtilities {
         return closest;
     }
 
+    public static int parseIndex(List list, String str) {
+        if(str.equalsIgnoreCase("last")) {
+            return list.size() - 1;
+        }
+        if(str.equalsIgnoreCase("first")) {
+            return 0;
+        }
+        int index;
+        try {
+            index = Integer.parseInt(str);
+        } catch (Exception ex) {
+            Debug.echoError("Invalid index '" + str + "': " + ex.getMessage());
+            return -1;
+        }
+        if(index == 0) {
+            Debug.echoError("0 is not a valid index");
+            return -1;
+        }
+        if (index < 0) {
+            return list.size() + Math.max(1 - list.size(), index) - 1;
+        }
+        return Math.min(list.size(), index) - 1;
+    }
+
     public static int indexOfAny(String str, int start, char... chars) {
         int earliest = -1;
         for (char c : chars) {

--- a/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
@@ -725,7 +725,7 @@ public class CoreUtilities {
             return -1;
         }
         if (index == 0) {
-            return 0;
+            return -1;
         }
         if (index < 0) {
             return Math.max(0, list.size() + index);

--- a/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
@@ -710,19 +710,20 @@ public class CoreUtilities {
     }
 
     public static int parseIndex(List list, String str) {
-        if(str.equalsIgnoreCase("last")) {
+        if (str.equalsIgnoreCase("last")) {
             return list.size() - 1;
         }
-        if(str.equalsIgnoreCase("first")) {
+        if (str.equalsIgnoreCase("first")) {
             return 0;
         }
         int index;
         try {
             index = Integer.parseInt(str);
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
             return -1;
         }
-        if(index == 0) {
+        if (index == 0) {
             return -1;
         }
         if (index < 0) {

--- a/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
@@ -720,11 +720,9 @@ public class CoreUtilities {
         try {
             index = Integer.parseInt(str);
         } catch (Exception ex) {
-            Debug.echoError("Invalid index '" + str + "': " + ex.getMessage());
             return -1;
         }
         if(index == 0) {
-            Debug.echoError("0 is not a valid index");
             return -1;
         }
         if (index < 0) {

--- a/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
@@ -728,7 +728,7 @@ public class CoreUtilities {
             return 0;
         }
         if (index < 0) {
-            return Math.max(0, list.size() + index - 1);
+            return Math.max(0, list.size() + index);
         }
         return Math.min(list.size(), index) - 1;
     }

--- a/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
@@ -710,10 +710,11 @@ public class CoreUtilities {
     }
 
     public static int parseIndex(List list, String str) {
-        if (str.equalsIgnoreCase("last")) {
+        str = toLowerCase(str);
+        if (str.equals("last")) {
             return list.size() - 1;
         }
-        if (str.equalsIgnoreCase("first")) {
+        if (str.equals("first")) {
             return 0;
         }
         int index;
@@ -724,10 +725,10 @@ public class CoreUtilities {
             return -1;
         }
         if (index == 0) {
-            return -1;
+            return 0;
         }
         if (index < 0) {
-            return list.size() + Math.max(1 - list.size(), index) - 1;
+            return Math.max(0, list.size() + index - 1);
         }
         return Math.min(list.size(), index) - 1;
     }


### PR DESCRIPTION
Created a generic index parser that handles the following:
- Negative numbers subtract from the end of the list (i.e. ListTag.get[-1] will return the second to last item)
- get[first] and get[last] now supported, parsing to the first and last indexes of the list
- Numbers higher than the list size or lower than the negative list size will parse to the first or last index
- Indexes passed in will have -1 applied to them to match java zero-indexing

I've tested each edge case on my test server to ensure everything works.