### PR TITLE
Codegen fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,8 +132,6 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.freneticllc.freneticutilities:freneticdatasyntax</include>
-                                    <include>org.ow2.asm:asm</include>
-                                    <include>org.ow2.asm:asm-commons</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/src/main/java/com/denizenscript/denizencore/DenizenImplementation.java
+++ b/src/main/java/com/denizenscript/denizencore/DenizenImplementation.java
@@ -83,8 +83,6 @@ public interface DenizenImplementation {
 
     boolean setSpecialDef(String def, ScriptQueue queue, ObjectTag value);
 
-    void saveClassToLoader(Class<?> clazz);
-
     void addExtraErrorHeaders(StringBuilder headerBuilder, ScriptEntry source);
 
     String applyDebugColors(String uncolored);

--- a/src/main/java/com/denizenscript/denizencore/utilities/codegen/CodeGenUtil.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/codegen/CodeGenUtil.java
@@ -15,17 +15,20 @@ public class CodeGenUtil {
 
     public static final String OBJECT_LOCAL_TYPE = "L" + Type.getInternalName(ObjectTag.class) + ";";
 
-    public static DynamicClassLoader loader = new DynamicClassLoader();
+    public static DynamicClassLoader loader = new DynamicClassLoader(CodeGenUtil.class.getClassLoader());
 
     public static String cleanName(String text) {
         return PERMITTED_NAME_CHARS.trimToMatches(text);
     }
 
     public static class DynamicClassLoader extends ClassLoader {
+        public DynamicClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
         public Class<?> define(String className, byte[] bytecode) {
             Class<?> clazz = super.defineClass(className, bytecode, 0, bytecode.length);
             resolveClass(clazz);
-            DenizenCore.implementation.saveClassToLoader(clazz);
             return clazz;
         }
         @Override


### PR DESCRIPTION
These changes are necessary for downstream projects that rely on projects such as Sponge's Mixins (in particular, Fabric mods). 
- Without changing the way ASM is shaded, Mixins will fail to detect the proper version. [An alternative to removal is available, if preferred.](https://discord.com/channels/315163488085475337/1011496047811506227/1025492624318136391)
- The DynamicClassLoader change allows automatic standard forwarding of defined classes to the existing ClassLoader at runtime. [This has the additional benefit of simplifying Denizen-Bukkit's implementation.](https://github.com/DenizenScript/Denizen/pull/2382)