### PR TITLE
Rename `registerTags` to `register`

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/ObjectFetcher.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/ObjectFetcher.java
@@ -251,9 +251,10 @@ public class ObjectFetcher {
             }
             newType.matches = getMatchesFor(objectTag);
             newType.valueOf = getValueOfFor(objectTag);
-            for (Method registerMethod: objectTag.getDeclaredMethods()) {
-                if (registerMethod.getName().equals("registerTags") && registerMethod.getParameterCount() == 0) {
+            for (Method registerMethod : objectTag.getDeclaredMethods()) {
+                if ((registerMethod.getName().equals("register") || registerMethod.getName().equals("registerTags")) && registerMethod.getParameterCount() == 0) {
                     registerMethod.invoke(null);
+                    break;
                 }
             }
         }

--- a/src/main/java/com/denizenscript/denizencore/objects/properties/PropertyParser.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/properties/PropertyParser.java
@@ -149,8 +149,9 @@ public class PropertyParser {
         currentlyRegisteringObjectType = ObjectFetcher.getType(object);
         try {
             for (Method registerMethod : property.getDeclaredMethods()) {
-                if (registerMethod.getName().equals("registerTags") && registerMethod.getParameterCount() == 0) {
+                if ((registerMethod.getName().equals("register") || registerMethod.getName().equals("registerTags")) && registerMethod.getParameterCount() == 0) {
                     registerMethod.invoke(null);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Changes

- `registerTags` in property / object classes was renamed to `register`, with `registerTags` still available for back-support.
- Added a `break` after finding and calling the `register` method - not sure if there's a specific reason there wasn't one before, lmk if that should be removed.