### PR TITLE
Move spigot impl features to core

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/scripts/commands/core/AdjustCommand.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/commands/core/AdjustCommand.java
@@ -117,10 +117,6 @@ public class AdjustCommand extends AbstractCommand {
 
     public static HashMap<String, Consumer<Mechanism>> specialAdjustables = new HashMap<>();
 
-    static {
-        specialAdjustables.put("system", UtilTagBase::adjustSystem);
-    }
-
     public ObjectTag adjust(ObjectTag object, String mechanismName, ObjectTag value, ScriptEntry entry) {
         Mechanism mechanism = new Mechanism(mechanismName, value, entry.entryData.getTagContext());
         return adjust(object, mechanism, entry);

--- a/src/main/java/com/denizenscript/denizencore/tags/core/UtilTagBase.java
+++ b/src/main/java/com/denizenscript/denizencore/tags/core/UtilTagBase.java
@@ -1031,6 +1031,8 @@ public class UtilTagBase extends PseudoObjectTagBase<UtilTagBase> {
         // Note that this redirects *all console output* not just Denizen output.
         // Note: don't enable /denizen debug -e while this is active.
         // Requires config file setting "Debug.Allow console redirection"!
+        // @example
+        // - adjust system redirect_logging:true
         // -->
         if (mechanism.matches("redirect_logging") && mechanism.hasValue()) {
             if (!CoreConfiguration.allowConsoleRedirection) {

--- a/src/main/java/com/denizenscript/denizencore/utilities/CoreConfiguration.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/CoreConfiguration.java
@@ -18,7 +18,7 @@ public class CoreConfiguration {
 
     public static int debugLimitPerTick = 5000, debugTrimLength = 1024, debugLineLength = 300;
 
-    public static boolean allowWebget = false, allowSQL = false, allowRedis = false, allowMongo = false, allowLog = false, allowFileCopy = false, allowWebserver = false, allowFileRead = false, allowFileWrite = false;
+    public static boolean allowWebget = false, allowSQL = false, allowRedis = false, allowMongo = false, allowLog = false, allowFileCopy = false, allowWebserver = false, allowFileRead = false, allowFileWrite = false, allowFileDeletion = false;
 
     public static boolean allowConsoleRedirection = false, allowRestrictedActions = false, allowStrangeFileSaves = false;
 


### PR DESCRIPTION
## Changes

- Moved registering the `system` special adjustable into `UtilTagBase`, as it makes more sense to register it in the same place it's handled imo.

## Additions (all moved from the Spigot implementation into Core)

- `util.debug_enabled` tag - returns whether script debug is enabled.
- `system.reset_event_stats` mechanism - resets `ScriptEvent` statistics.
- `system.cleanmem` mechanism - suggests putting more effort towards towards clearing unused objects to Java.
- `system.delete_file` mechanism - deletes a file.
- `CoreConfiguration.allowFileDeletion` - whether file deletion is allowed.