### PR TITLE
Fix flag tab complete

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/utilities/ExCommandHelper.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/ExCommandHelper.java
@@ -221,10 +221,10 @@ public class ExCommandHelper {
                         }
                         else {
                             String tagPiece = subComponent.substring(0, squareBracket);
-                            String argUntilParam = arg.substring(0, relevantTagStart) + fullTag.substring(0, lastDot + squareBracket + 1);
                             if (tagPiece.startsWith("flag") || tagPiece.equals("has_flag")) {
                                 completionsBuilder.arg = subComponent.substring(squareBracket + 1);
                                 FlagCommand.tabCompleteFlag(completionsBuilder);
+                                String argUntilParam = arg.substring(0, relevantTagStart) + fullTag.substring(0, lastDot + squareBracket + 1);
                                 completionsBuilder.completions.replaceAll(argUntilParam::concat);
                                 return completionsBuilder.completions;
                             }

--- a/src/main/java/com/denizenscript/denizencore/utilities/ExCommandHelper.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/ExCommandHelper.java
@@ -221,9 +221,11 @@ public class ExCommandHelper {
                         }
                         else {
                             String tagPiece = subComponent.substring(0, squareBracket);
+                            String argUntilParam = arg.substring(0, relevantTagStart) + fullTag.substring(0, lastDot + squareBracket + 1);
                             if (tagPiece.startsWith("flag") || tagPiece.equals("has_flag")) {
                                 completionsBuilder.arg = subComponent.substring(squareBracket + 1);
                                 FlagCommand.tabCompleteFlag(completionsBuilder);
+                                completionsBuilder.completions.replaceAll(argUntilParam::concat);
                                 return completionsBuilder.completions;
                             }
                         }


### PR DESCRIPTION
![FlagTabCompleteExample](https://user-images.githubusercontent.com/31237389/229626931-e5e5cc81-7e2f-46be-a238-849f67ab1bda.gif)

Previously tab-completing a flag name would wipe the entire arg, as it didn't include the previously typed part in the suggestions; It should now properly append the arg so far onto them.

Reported by mergu @ https://discord.com/channels/315163488085475337/1091965977803116544