### PR TITLE
`parse_value` tag

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
@@ -2310,7 +2310,7 @@ public class ListTag implements List<String>, ObjectTag {
         // One should generally prefer <@link tag ListTag.filter_tag>.
         // @Example
         // # Narrates a list of '3|4|5'
-        // - narrate "<list[1|2|3|4|5].filter[is_more_than[3]]>
+        // - narrate <list[1|2|3|4|5].filter[is_more_than[3]]>
         // -->
         tagProcessor.registerTag(ListTag.class, "filter", (attribute, object) -> {
             String tag = attribute.getRawParam();
@@ -2351,7 +2351,7 @@ public class ListTag implements List<String>, ObjectTag {
         // One should generally prefer <@link tag ListTag.parse_tag>.
         // @Example
         // # Narrates a list of 'ONE|TWO'
-        // - narrate "<list[one|two].parse[to_uppercase]>
+        // - narrate <list[one|two].parse[to_uppercase]>
         // -->
         tagProcessor.registerTag(ListTag.class, "parse", (attribute, object) -> {
             ListTag newlist = new ListTag();
@@ -2410,10 +2410,10 @@ public class ListTag implements List<String>, ObjectTag {
         // This requires a fully formed tag as input, making use of the 'filter_value' definition.
         // @Example
         // # Narrates a list of '3|4|5'
-        // - narrate "<list[1|2|3|4|5].filter_tag[<[filter_value].is_more_than[3]>]>
+        // - narrate <list[1|2|3|4|5].filter_tag[<[filter_value].is_more_than[3]>]>
         // @Example
         // # Narrates a list of '4|5'
-        // - narrate "<list[1|2|3|4|5].filter_tag[<list[4|5].contains[<[filter_value]>]>]>
+        // - narrate <list[1|2|3|4|5].filter_tag[<list[4|5].contains[<[filter_value]>]>]>
         // -->
         tagProcessor.registerTag(ListTag.class, "filter_tag", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -2443,10 +2443,10 @@ public class ListTag implements List<String>, ObjectTag {
         // This requires a fully formed tag as input, making use of the 'parse_value' definition.
         // @Example
         // # Narrates a list of 'ONE|TWO'
-        // - narrate "<list[one|two].parse_tag[<[parse_value].to_uppercase>]>
+        // - narrate <list[one|two].parse_tag[<[parse_value].to_uppercase>]>
         // @Example
         // # Narrates a list of 'charlie|alpha|bravo'
-        // - narrate "<list[3|1|2].parse_tag[<list[alpha|bravo|charlie].get[<[parse_value]>]>]>
+        // - narrate <list[3|1|2].parse_tag[<list[alpha|bravo|charlie].get[<[parse_value]>]>]>
         // -->
         tagProcessor.registerTag(ListTag.class, "parse_tag", (attribute, object) -> {
             if (!attribute.hasParam()) {

--- a/src/main/java/com/denizenscript/denizencore/objects/core/MapTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/MapTag.java
@@ -938,7 +938,7 @@ public class MapTag implements ObjectTag {
         // Returns a copy of the map with all its values updated through the given tag.
         // One should generally prefer <@link tag MapTag.parse_value_tag>.
         // @Example
-        // # Narrates a map of 'alpha=ONE;beta=TWO'
+        // # Narrates a map of '[alpha=ONE;beta=TWO]'
         // - narrate <map[alpha=one;bravo=two].parse[to_uppercase]>
         // -->
         tagProcessor.registerTag(MapTag.class, "parse_value", (attribute, object) -> {

--- a/src/main/java/com/denizenscript/denizencore/objects/core/MapTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/MapTag.java
@@ -938,7 +938,7 @@ public class MapTag implements ObjectTag {
         // Returns a copy of the map with all its values updated through the given tag.
         // One should generally prefer <@link tag MapTag.parse_value_tag>.
         // @Example
-        // # Narrates a list of 'alpha=ONE;beta=TWO'
+        // # Narrates a map of 'alpha=ONE;beta=TWO'
         // - narrate <map[alpha=one;bravo=two].parse[to_uppercase]>
         // -->
         tagProcessor.registerTag(MapTag.class, "parse_value", (attribute, object) -> {

--- a/src/main/java/com/denizenscript/denizencore/objects/core/MapTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/MapTag.java
@@ -968,7 +968,8 @@ public class MapTag implements ObjectTag {
            Attribute subAttribute;
            try {
                subAttribute = new Attribute(tag, attribute.getScriptEntry(), attribute.context);
-           } catch (TagProcessingException ex) {
+           }
+           catch (TagProcessingException ex) {
                attribute.echoError("Tag processing failed: " + ex.getMessage());
                return null;
            }
@@ -982,7 +983,8 @@ public class MapTag implements ObjectTag {
                    }
                    newMap.putObject(entry.getKey().toString(), objs);
                }
-           } catch (Exception ex) {
+           }
+           catch (Exception ex) {
                Debug.echoError(ex);
            }
            return newMap;

--- a/src/main/java/com/denizenscript/denizencore/objects/core/MapTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/MapTag.java
@@ -939,7 +939,7 @@ public class MapTag implements ObjectTag {
         // One should generally prefer <@link tag MapTag.parse_value_tag>.
         // @Example
         // # Narrates a map of '[alpha=ONE;beta=TWO]'
-        // - narrate <map[alpha=one;bravo=two].parse[to_uppercase]>
+        // - narrate <map[alpha=one;bravo=two].parse_value[to_uppercase]>
         // -->
         tagProcessor.registerTag(MapTag.class, "parse_value", (attribute, object) -> {
            MapTag newMap = new MapTag();


### PR DESCRIPTION
### `<MapTag.parse_value[<tag>]>`

Does the same thing as `<ListTag.parse[<tag>]>` but for map values, instead of typing the longer version of `<MapTag.parse_value_tag[<parseable-value>]>`.

Requested by [Krilliant](https://discord.com/channels/315163488085475337/1114571305459658863)

Also changed some meta examples to remove a single `"` at the start of the narrate.