### PR TITLE
Modern determination system

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/events/ScriptEvent.java
+++ b/src/main/java/com/denizenscript/denizencore/events/ScriptEvent.java
@@ -690,7 +690,7 @@ public abstract class ScriptEvent implements ContextSource, Cloneable {
             defaultHandler.accept(getTagContext(path), value);
             return;
         }
-        applyDetermination(path, prefix != null ? new ElementTag(prefix + ':' + value, true) : value);
+        return applyDetermination(path, prefix != null ? new ElementTag(prefix + ':' + value) : value);
     }
 
     public ScriptEntryData getScriptEntryData() {

--- a/src/main/java/com/denizenscript/denizencore/events/ScriptEvent.java
+++ b/src/main/java/com/denizenscript/denizencore/events/ScriptEvent.java
@@ -651,17 +651,6 @@ public abstract class ScriptEvent implements ContextSource, Cloneable {
         return false;
     }
 
-    public final void registerTextDetermination(String determination, Runnable handler) {
-        registerDetermination(determination, ObjectTag.class, (context, objectTag) -> handler.run());
-    }
-
-    public final <T extends ObjectTag> void registerDetermination(String prefix, Class<T> inputType, BiConsumer<TagContext, T> handler) {
-        registerOptionalDetermination(prefix, inputType, (context, determination) -> {
-            handler.accept(context, determination);
-            return true;
-        });
-    }
-
     public final <T extends ObjectTag> void registerOptionalDetermination(String prefix, Class<T> inputType, DeterminationHandler<T> handler) {
         eventData.determinations.put(prefix != null ? CoreUtilities.toLowerCase(prefix) : null, (context, objectTag) -> {
             T converted = objectTag.asType(inputType, context);
@@ -671,6 +660,17 @@ public abstract class ScriptEvent implements ContextSource, Cloneable {
             }
             return handler.handle(context, converted);
         });
+    }
+
+    public final <T extends ObjectTag> void registerDetermination(String prefix, Class<T> inputType, BiConsumer<TagContext, T> handler) {
+        registerOptionalDetermination(prefix, inputType, (context, determination) -> {
+            handler.accept(context, determination);
+            return true;
+        });
+    }
+
+    public final void registerTextDetermination(String determination, Runnable handler) {
+        registerDetermination(determination, ObjectTag.class, (context, objectTag) -> handler.run());
     }
 
     @Deprecated(forRemoval = true)

--- a/src/main/java/com/denizenscript/denizencore/events/ScriptEvent.java
+++ b/src/main/java/com/denizenscript/denizencore/events/ScriptEvent.java
@@ -679,14 +679,15 @@ public abstract class ScriptEvent implements ContextSource, Cloneable {
             modifiedValue = new ElementTag(true);
         }
         if (modifiedPrefix != null) {
-            modifiedPrefix = CoreUtilities.toLowerCase(modifiedPrefix);
+            BiConsumer<TagContext, ObjectTag> determinationHandler = eventData.determinations.get(CoreUtilities.toLowerCase(modifiedPrefix));
+            if (determinationHandler != null) {
+                determinationHandler.accept(getTagContext(path), modifiedValue);
+                return;
+            }
         }
-        BiConsumer<TagContext, ObjectTag> determinationHandler = eventData.determinations.get(modifiedPrefix);
-        if (determinationHandler == null) {
-            determinationHandler = eventData.determinations.get(null);
-        }
-        if (determinationHandler != null) {
-            determinationHandler.accept(getTagContext(path), modifiedValue);
+        BiConsumer<TagContext, ObjectTag> defaultHandler = eventData.determinations.get(null);
+        if (defaultHandler != null) {
+            defaultHandler.accept(getTagContext(path), value);
             return;
         }
         applyDetermination(path, prefix != null ? new ElementTag(prefix + ':' + value, true) : value);

--- a/src/main/java/com/denizenscript/denizencore/events/core/CustomScriptEvent.java
+++ b/src/main/java/com/denizenscript/denizencore/events/core/CustomScriptEvent.java
@@ -55,6 +55,7 @@ public class CustomScriptEvent extends ScriptEvent {
         instance = this;
         registerCouldMatcher("custom event");
         registerSwitches("id", "data");
+        registerDetermination("output", ObjectTag.class, (context, output) -> determinations.addObject(output));
     }
 
     @Override
@@ -104,15 +105,6 @@ public class CustomScriptEvent extends ScriptEvent {
             }
         }
         return super.getContext(name);
-    }
-
-    @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determination) {
-        if (determination instanceof ElementTag && CoreUtilities.toLowerCase(determination.toString()).startsWith("output:")) {
-            determinations.add(determination.toString().substring("output:".length()));
-            return true;
-        }
-        return super.applyDetermination(path, determination);
     }
 
     boolean enabled = false;

--- a/src/main/java/com/denizenscript/denizencore/scripts/queues/DeterminationTarget.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/queues/DeterminationTarget.java
@@ -4,5 +4,5 @@ import com.denizenscript.denizencore.objects.ObjectTag;
 
 public interface DeterminationTarget {
 
-    void applyDetermination(ObjectTag determination);
+    void applyDetermination(String prefix, ObjectTag value);
 }


### PR DESCRIPTION
Modernizes script event determinations using prefix-based registration. 

## Additions

- `ScriptEvent$InternalEventData.determinations` - map of determination prefixes to their handlers.
- `ScriptEvent$DeterminationHandler` - functional interface for determinations; takes a tag context and a value, and returns whether it was properly handled.
- `ScriptEvent#registerDetermination` - registers a prefixed determination with a specific input type.
- `ScriptEvent#registerOptionalDetermination` - registers an optional prefixed determination; a determination that returns whether it was properly handled.
- `ScriptEvent#registerTextDetermination` - registers a raw text determination (I.e. doesn't have input, just a String); basically an overload for the method above (see `Notes`).
- `WebserverWebRequestScriptEvent#registerResponseDetermination` - util for determinations that set the response (and need to make sure there isn't an existing one already).
- `WebserverWebRequestScriptEvent#handleFileDetermination` - file determination logic, used by relevant determinations.

## Changes

- `handleBaseDetermination(ScriptPath, ObjectTag)` -> `handleDetermination(ScriptPath, String, ObjectTag)`.
- Updated `CustomScriptEvent` to modern determination handling.
- Updated `WebserverWebRequestScriptEvent` to modern determination handling
- Removed `passive` as a boolean arg from `determine`, as it seems only `passively` was actually supported in the code anyway?
- Updated `determine` meta example to use a prefixed determination.
- `DetermineCommand` now passes in the `Argument` object itself from `parseArgs`, to be handled in `execute`.
- Currently removed the weird defaulting to `none` behavior - as far as I can see the arg has been documented as required since the meta was created, and doesn't really make sense to have a default value there? let me know if that should be changed back.
- Removed the `defaultObject` call for `passively`, as that just... wasn't doing anything afaics.
- `DeterminationTarget` now takes a `String prefix` and `ObjectTag` value.
- Deprecated `applyDetermination` for removal, as all events should be updated for the registration system now.

## Notes

- When there isn't a prefix and the value is an `ElementTag`, the prefix will become the value and the value will become `true` - this is to support using the same registration for prefixed and text determinations.