### PR TITLE
Multi line tags

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
@@ -99,8 +99,7 @@ public class ScriptHelper {
 
     public static String clearComments(String filename, String input, boolean trackSources) {
         StringBuilder result = new StringBuilder(input.length());
-        String[] linesArray = input.replace("\t", "    ").replace("\r", "").split("\n");
-        List<String> lines = new ArrayList<>(Arrays.asList(linesArray));
+        List<String> lines = new ArrayList<>(Arrays.asList(input.replace("\t", "    ").replace("\r", "").split("\n")));
         boolean hasAnyScript = false;
         int lineNum = 0;
         for (int i = 0; i < lines.size(); i++) {

--- a/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
@@ -102,8 +102,9 @@ public class ScriptHelper {
         String[] linesArray = input.replace("\t", "    ").replace("\r", "").split("\n");
         List<String> lines = new ArrayList<>(Arrays.asList(linesArray));
         boolean hasAnyScript = false;
-        for (int lineNum = 0; lineNum < lines.size(); lineNum++) {
-            String line = lines.get(lineNum);
+        int lineNum = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
             String trimmedLine = line.trim();
             String trimStart = line.replaceAll("^[\\s]+", "");
             if (trackSources && !trimmedLine.startsWith("#") && trimStart.length() == line.length() && trimmedLine.endsWith(":") && trimmedLine.length() > 1) {
@@ -142,7 +143,9 @@ public class ScriptHelper {
                 if (trimmedLine.startsWith("- ") && !trimmedLine.startsWith("- \"") && !trimmedLine.startsWith("- '")) {
                     int nextLine = lineNum + 1;
                     if (nextLine < lines.size() && lines.get(nextLine).stripLeading().startsWith(".")) {
+                        int linesBefore = lines.size();
                         curLine = inlineTagsForCommand(curLine, lineNum, lines);
+                        lineNum += linesBefore - lines.size();
                     }
                     int dashIndex = curLine.indexOf('-');
                     curLine = curLine.substring(0, dashIndex + 1) + " " + ScriptBuilder.LINE_PREFIX_CHAR + (lineNum + 1) + ScriptBuilder.LINE_PREFIX_CHAR + curLine.substring(dashIndex + 1);
@@ -152,6 +155,7 @@ public class ScriptHelper {
             else {
                 result.append("\n");
             }
+            lineNum++;
         }
         result.append("\n");
         return result.toString();

--- a/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
@@ -104,6 +104,7 @@ public class ScriptHelper {
         boolean hasAnyScript = false;
         int lineNum = 0;
         for (int i = 0; i < lines.size(); i++) {
+            lineNum++;
             String line = lines.get(i);
             String trimmedLine = line.trim();
             String trimStart = line.replaceAll("^[\\s]+", "");
@@ -141,21 +142,20 @@ public class ScriptHelper {
                     curLine = curLine.substring(0, colon + 1) + CoreUtilities.replace(curLine.substring(colon + 1), ":", "<&co>");
                 }
                 if (trimmedLine.startsWith("- ") && !trimmedLine.startsWith("- \"") && !trimmedLine.startsWith("- '")) {
-                    int nextLine = lineNum + 1;
+                    int nextLine = i + 1;
                     if (nextLine < lines.size() && lines.get(nextLine).stripLeading().startsWith(".")) {
-                        int linesBefore = lines.size();
-                        curLine = inlineTagsForCommand(curLine, lineNum, lines);
-                        lineNum += linesBefore - lines.size();
+                        int lineCountBefore = lines.size();
+                        curLine = inlineTagsForCommand(curLine, i, lines);
+                        lineNum += lineCountBefore - lines.size();
                     }
                     int dashIndex = curLine.indexOf('-');
-                    curLine = curLine.substring(0, dashIndex + 1) + " " + ScriptBuilder.LINE_PREFIX_CHAR + (lineNum + 1) + ScriptBuilder.LINE_PREFIX_CHAR + curLine.substring(dashIndex + 1);
+                    curLine = curLine.substring(0, dashIndex + 1) + " " + ScriptBuilder.LINE_PREFIX_CHAR + lineNum + ScriptBuilder.LINE_PREFIX_CHAR + curLine.substring(dashIndex + 1);
                 }
                 result.append(curLine).append("\n");
             }
             else {
                 result.append("\n");
             }
-            lineNum++;
         }
         result.append("\n");
         return result.toString();

--- a/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
@@ -142,14 +142,14 @@ public class ScriptHelper {
                     curLine = curLine.substring(0, colon + 1) + CoreUtilities.replace(curLine.substring(colon + 1), ":", "<&co>");
                 }
                 if (trimmedLine.startsWith("- ") && !trimmedLine.startsWith("- \"") && !trimmedLine.startsWith("- '")) {
+                    int dashIndex = curLine.indexOf('-');
+                    curLine = curLine.substring(0, dashIndex + 1) + " " + ScriptBuilder.LINE_PREFIX_CHAR + lineNum + ScriptBuilder.LINE_PREFIX_CHAR + curLine.substring(dashIndex + 1);
                     int nextLine = i + 1;
                     if (nextLine < lines.size() && lines.get(nextLine).stripLeading().startsWith(".")) {
                         int lineCountBefore = lines.size();
                         curLine = inlineTagsForCommand(curLine, i, lines);
                         lineNum += lineCountBefore - lines.size();
                     }
-                    int dashIndex = curLine.indexOf('-');
-                    curLine = curLine.substring(0, dashIndex + 1) + " " + ScriptBuilder.LINE_PREFIX_CHAR + lineNum + ScriptBuilder.LINE_PREFIX_CHAR + curLine.substring(dashIndex + 1);
                 }
                 result.append(curLine).append("\n");
             }

--- a/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/ScriptHelper.java
@@ -109,7 +109,7 @@ public class ScriptHelper {
             String trimmedLine = line.trim();
             String trimStart = line.replaceAll("^[\\s]+", "");
             if (trackSources && !trimmedLine.startsWith("#") && trimStart.length() == line.length() && trimmedLine.endsWith(":") && trimmedLine.length() > 1) {
-                String name = trimmedLine.substring(0, trimmedLine.length() - 1).replace('\"', '\'').replace("'", "");
+                String name = trimmedLine.substring(0, trimmedLine.length() - 1).replace('"', '\'').replace("'", "");
                 scriptSourcesInprogress.put(CoreUtilities.toLowerCase(name), filename);
                 scriptOriginalNamesInprogress.put(CoreUtilities.toLowerCase(name), name);
                 result.append(CoreUtilities.toUpperCase(name)).append(":\n");
@@ -135,7 +135,7 @@ public class ScriptHelper {
                 }
                 else if (!startsDash && (trimmedLine.contains(": &") || trimmedLine.contains(": *") || trimmedLine.contains(": !"))) {
                     int colon = curLine.indexOf(':');
-                    curLine = curLine.substring(0, colon) + ": \"" + curLine.substring(colon + 2).replace("\"", "<&dq>") + "\"";
+                    curLine = curLine.substring(0, colon) + ": \"" + curLine.substring(colon + 2).replace("\"", "<&dq>") + '"';
                 }
                 else if (!endsColon) {
                     int colon = curLine.indexOf(':');
@@ -143,7 +143,7 @@ public class ScriptHelper {
                 }
                 if (trimmedLine.startsWith("- ") && !trimmedLine.startsWith("- \"") && !trimmedLine.startsWith("- '")) {
                     int dashIndex = curLine.indexOf('-');
-                    curLine = curLine.substring(0, dashIndex + 1) + " " + ScriptBuilder.LINE_PREFIX_CHAR + lineNum + ScriptBuilder.LINE_PREFIX_CHAR + curLine.substring(dashIndex + 1);
+                    curLine = curLine.substring(0, dashIndex + 1) + ' ' + ScriptBuilder.LINE_PREFIX_CHAR + lineNum + ScriptBuilder.LINE_PREFIX_CHAR + curLine.substring(dashIndex + 1);
                     int nextLine = i + 1;
                     if (nextLine < lines.size() && lines.get(nextLine).stripLeading().startsWith(".")) {
                         int lineCountBefore = lines.size();
@@ -151,10 +151,10 @@ public class ScriptHelper {
                         lineNum += lineCountBefore - lines.size();
                     }
                 }
-                result.append(curLine).append("\n");
+                result.append(curLine).append('\n');
             }
             else {
-                result.append("\n");
+                result.append('\n');
             }
         }
         result.append("\n");


### PR DESCRIPTION
Adds support for splitting tags over multiple lines, by automatically in-lining them when loading the script file.
The logic currently is just: when parsing a command line, if the next line starts with a `.`, start appending and removing every line after it to the command until you run out of lines/reach one that doesn't start with a `.`.

## Changes

- Changed `lines` into a `List<String>` to allow removing lines (the tag parts).
- Split line number tracking and the loop index, as the line number might be bigger then the list due to multi-line tags being merged.
- Some minor cleanups (mainly replacing single character strings with just a char/removing some redundant escaping ( e.g. `'\"'` can be just `'"'`).

## Additions

- A `String line = lines.get(i)` variable instead of re-getting it every time.
- `ScriptHelper#inlineTagsForCommand(String command, int commandLine, List<String> lines)` - util method that in-lines a multi-line tag using the logic described above.