### PR TITLE
`<ElementTag.millis_to_time>`

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2497,6 +2497,16 @@ public class ElementTag implements ObjectTag {
         tagProcessor.registerStaticTag(MapTag.class, "parse_yaml", (attribute, object) -> {
             return (MapTag) CoreUtilities.objectToTagForm(YamlConfiguration.load(object.asString()).contents, attribute.context);
         });
+
+        // <--[tag]
+        // @attribute <ElementTag.millis_to_time>
+        // @returns TimeTag
+        // @description
+        // Returns a TimeTag from the number of milliseconds since Jan 1, 1970.
+        // -->
+        tagProcessor.registerStaticTag(TimeTag.class, "millis_to_time", (attribute, object) -> {
+            return new TimeTag(object.asLong());
+        });
     }
 
     public static ObjectTagProcessor<ElementTag> tagProcessor = new ObjectTagProcessor<>();

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2506,8 +2506,10 @@ public class ElementTag implements ObjectTag {
         // Returns a TimeTag constructed from the number of milliseconds after the Unix Epoch (Jan. 1st 1970).
         // See also <@link tag util.current_time_millis> and <@link tag TimeTag.epoch_millis>.
         // @example
-        // # Narrates '2024/03/22 02:41:19'.
-        // - narrate <element[1711075279797].millis_to_time.format>
+        // - define time_now_millis <util.current_time_millis>
+        // # Do a long task...
+        // # If the task took 10 seconds to complete, this would narrate "Task took 10 seconds to complete!"
+        // - narrate "Task took <util.time_now.duration_since[<[time_now_millis].millis_to_time>].formatted_words> to complete!"
         // -->
         tagProcessor.registerStaticTag(TimeTag.class, "millis_to_time", (attribute, object) -> {
             return new TimeTag(object.asLong());

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2501,6 +2501,7 @@ public class ElementTag implements ObjectTag {
         // <--[tag]
         // @attribute <ElementTag.millis_to_time>
         // @returns TimeTag
+        // @group conversion
         // @description
         // Returns a TimeTag from the number of milliseconds since Jan 1, 1970.
         // -->

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2503,7 +2503,11 @@ public class ElementTag implements ObjectTag {
         // @returns TimeTag
         // @group conversion
         // @description
-        // Returns a TimeTag from the number of milliseconds since Jan 1, 1970.
+        // Returns a TimeTag constructed from the number of milliseconds after the Unix Epoch (Jan. 1st 1970).
+        // See also <@link tag util.current_time_millis> and <@link tag TimeTag.epoch_millis>.
+        // @example
+        // # Narrates '2024/03/22 02:41:19'.
+        // - narrate <element[1711075279797].millis_to_time.format>
         // -->
         tagProcessor.registerStaticTag(TimeTag.class, "millis_to_time", (attribute, object) -> {
             return new TimeTag(object.asLong());

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2506,10 +2506,9 @@ public class ElementTag implements ObjectTag {
         // Returns a TimeTag constructed from the number of milliseconds after the Unix Epoch (Jan. 1st 1970).
         // See also <@link tag util.current_time_millis> and <@link tag TimeTag.epoch_millis>.
         // @example
-        // - define time_now_millis <util.current_time_millis>
-        // # Do a long task...
-        // # If the task took 10 seconds to complete, this would narrate "Task took 10 seconds to complete!"
-        // - narrate "Task took <util.time_now.duration_since[<[time_now_millis].millis_to_time>].formatted_words> to complete!"
+        // # Takes an arbitrary unix timestamp from an external source, and formats it for a user-friendly date/time display message.
+        // - define some_unix_timestamp <util.time_now.epoch_millis>
+        // - narrate "The timestamp was <[some_unix_timestamp].millis_to_time.format>"
         // -->
         tagProcessor.registerStaticTag(TimeTag.class, "millis_to_time", (attribute, object) -> {
             return new TimeTag(object.asLong());

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2503,7 +2503,7 @@ public class ElementTag implements ObjectTag {
         // @returns TimeTag
         // @group conversion
         // @description
-        // Returns a TimeTag constructed from the number of milliseconds after the Unix Epoch (Jan. 1st 1970).
+        // Returns a TimeTag constructed from the given number of milliseconds after the Unix Epoch (Jan. 1st 1970).
         // See also <@link tag util.current_time_millis> and <@link tag TimeTag.epoch_millis>.
         // @example
         // # Takes an arbitrary unix timestamp from an external source, and formats it for a user-friendly date/time display message.


### PR DESCRIPTION
# `<ElementTag.millis_to_time>`

Adds a tag to convert epoch milliseconds to a TimeTag.

(Requested by [Hatzefatz](https://discord.com/channels/315163488085475337/1215129741431021618))