### PR TITLE
`ReflectionHelper`: Paper mapping change compact

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/core/JavaReflectedObjectTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/JavaReflectedObjectTag.java
@@ -274,7 +274,9 @@ public class JavaReflectedObjectTag implements ObjectTag {
             ListTag fields = new ListTag();
             Class<?> clazz = object.object.getClass();
             while (clazz != Object.class) {
-                fields.addAll(ReflectionHelper.getFields(clazz).keySet());
+                for (Field field : ReflectionHelper.getFields(clazz).getAllFields()) {
+                    fields.add(field.getName());
+                }
                 clazz = clazz.getSuperclass();
             }
             return fields;


### PR DESCRIPTION
See discussion on [Discord](https://discord.com/channels/315163488085475337/1011496047811506227/1236682923768287233).

## Changes

- `CheckingFieldMap` now dynamically gets fields when needed using `Class#getDeclaredField` and caches them, which is done in `getNoCheck`.
- `CheckingFieldMap#getFirstOfType` now caches all fields in the new `Field[] allFields` and finds fields based on that.
- `CheckingFieldMap#get` now uses `getNoCheck` to handle finding the field if needed.
- `ReflectionHelper#getFields` now just gets or creates a `CheckingFieldMap` for the class, as all logic is handled within `CheckingFieldMap`.
- `ReflectionHelper#getMethod` now uses `Class#getDeclaredMethod` instead of the permissive param matching it had before - this is technically a breaking change, but as far as I can see nothing was using this, and there are no errors at startup (and either way updating usages for this is very easy if there is one somewhere).

> [!NOTE]
> `ReflectionHelper#getFinalSetterForFirstOfType` uses `Field#getName`, which means some cache maps might have the field twice (mojmap and obf names).
> This shouldn't be an issue, but in theory the names could clash - best way to solve this afaics is to just not put the field into the cache in `getFinalSetterForFirstOfType`, especially since static final fields (or anything this method is used for) are likely not ever accessed anywhere else (and at the worst case scenario it's 1 extra lookup getting it by name), so let me know if this should be done.