### PR TITLE
Add `<ElementTag.unaccented>`

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2519,14 +2519,17 @@ public class ElementTag implements ObjectTag {
         // @attribute <ElementTag.unaccented>
         // @returns ElementTag
         // @description
-        // Returns a modified version of the input text but with all the accents removed and replaced with their normalized counterparts.
+        // Returns the input text with any the accented characters replaced with their base counterparts.
         // Note that not all characters have a normalized form, such as "æ", and will be unchanged.
         // @example
         // # Narrates "TqaaCwIMæ"
         // - narrate <element[ⓉⓠäắÇẘℑℳæ].unaccented>
+        // @example
+        // # Narrates "these characters have diacritics: eac"
+        // - narrate <element[these characters have diacritics: éàç].unaccented>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "unaccented", (attribute, object) -> {
-            return new ElementTag(Normalizer.normalize(object.asString(), Normalizer.Form.NFKD).replaceAll("[\\u0300-\\u036f]", ""));
+            return new ElementTag(unaccentedPattern.matcher(Normalizer.normalize(object.asString(), Normalizer.Form.NFKD)).replaceAll(""), true);
         });
     }
 
@@ -2599,4 +2602,6 @@ public class ElementTag implements ObjectTag {
         }
         return ScriptEvent.runGenericCheck(matcher, element);
     }
+
+    public static Pattern unaccentedPattern = Pattern.compile("[\\u0300-\\u036f]");
 }

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2519,7 +2519,7 @@ public class ElementTag implements ObjectTag {
         // @attribute <ElementTag.unaccented>
         // @returns ElementTag
         // @description
-        // Returns the input text with any the accented characters replaced with their base counterparts.
+        // Returns the input text with any accented characters replaced with their base counterparts.
         // Note that not all characters have a normalized form, such as "æ", and will be unchanged.
         // @example
         // # Narrates "TqaaCwIMæ"

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -16,6 +16,7 @@ import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.regex.Matcher;
@@ -2512,6 +2513,20 @@ public class ElementTag implements ObjectTag {
         // -->
         tagProcessor.registerStaticTag(TimeTag.class, "millis_to_time", (attribute, object) -> {
             return new TimeTag(object.asLong());
+        });
+
+        // <--[tag]
+        // @attribute <ElementTag.unaccented>
+        // @returns ElementTag
+        // @description
+        // Returns a modified version of the input text but with all the accents removed and replaced with their normalized counterparts.
+        // Note that not all characters have a normalized form, such as "æ", and will be unchanged.
+        // @example
+        // # Narrates "TqaaCwIMæ"
+        // - narrate <element[ⓉⓠäắÇẘℑℳæ].unaccented>
+        // -->
+        tagProcessor.registerStaticTag(ElementTag.class, "unaccented", (attribute, object) -> {
+            return new ElementTag(Normalizer.normalize(object.asString(), Normalizer.Form.NFKD).replaceAll("[\\u0300-\\u036f]", ""));
         });
     }
 


### PR DESCRIPTION
### `<ElementTag.unaccented>`

Removes accents from characters.

Notes:
- Like mentioned in the feature thread, not all characters have a "normalized" unaccented version because they are actual letters without accents like **œ**.
- The regex was given by Apademide and it removes all of the accent marks after the `normalize` method separates the character and the accent.

Requested by [Apademide](https://discord.com/channels/315163488085475337/1241824031519277117/1241824031519277117).