### PR TITLE
`TagContext` in object matchers

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/events/ScriptEvent.java
+++ b/src/main/java/com/denizenscript/denizencore/events/ScriptEvent.java
@@ -214,6 +214,7 @@ public abstract class ScriptEvent implements ContextSource, Cloneable {
         public List<String> matchFailReasons = null;
         public double switch_chance;
         public List<String> switch_serverFlagged;
+        public TagContext context;
 
         public String rawEventArgAt(int index) {
             return index < rawEventArgs.length ? rawEventArgs[index] : "";
@@ -301,14 +302,14 @@ public abstract class ScriptEvent implements ContextSource, Cloneable {
             if (obj == null) {
                 return false;
             }
-            return obj.tryAdvancedMatcher(val);
+            return obj.tryAdvancedMatcher(val, context);
         }
 
         public boolean tryArgObject(int argIndex, ObjectTag obj) {
             if (obj == null) {
                 return false;
             }
-            return obj.tryAdvancedMatcher(eventArgAt(argIndex));
+            return obj.tryAdvancedMatcher(eventArgAt(argIndex), context);
         }
 
         // <--[data]
@@ -607,7 +608,10 @@ public abstract class ScriptEvent implements ContextSource, Cloneable {
                 return false;
             }
         }
-        return sEvent.matches(path);
+        path.context = sEvent.getTagContext(path);
+        boolean matches = sEvent.matches(path);
+        path.context = null;
+        return matches;
     }
 
     /**

--- a/src/main/java/com/denizenscript/denizencore/events/core/CustomScriptEvent.java
+++ b/src/main/java/com/denizenscript/denizencore/events/core/CustomScriptEvent.java
@@ -80,7 +80,7 @@ public class CustomScriptEvent extends ScriptEvent {
                 if (val == null) {
                     return false;
                 }
-                if (!val.tryAdvancedMatcher(parts.get(1), getTagContext(path))) {
+                if (!val.tryAdvancedMatcher(parts.get(1), path.context)) {
                     return false;
                 }
             }

--- a/src/main/java/com/denizenscript/denizencore/events/core/CustomScriptEvent.java
+++ b/src/main/java/com/denizenscript/denizencore/events/core/CustomScriptEvent.java
@@ -80,7 +80,7 @@ public class CustomScriptEvent extends ScriptEvent {
                 if (val == null) {
                     return false;
                 }
-                if (!val.tryAdvancedMatcher(parts.get(1))) {
+                if (!val.tryAdvancedMatcher(parts.get(1), getTagContext(path))) {
                     return false;
                 }
             }

--- a/src/main/java/com/denizenscript/denizencore/objects/ObjectTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/ObjectTag.java
@@ -260,6 +260,14 @@ public interface ObjectTag {
      * Used for objects to override, should not be called externally. Call 'tryAdvancedMatcher' instead.
      */
     default boolean advancedMatches(String matcher, TagContext context) {
+        return advancedMatches(matcher);
+    }
+
+    /**
+     * @deprecated {@link #advancedMatches(String, TagContext)} should be implemented instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean advancedMatches(String matcher) {
         return ScriptEvent.runGenericCheck(matcher, identify());
     }
 
@@ -288,6 +296,14 @@ public interface ObjectTag {
             }
         }
         return advancedMatches(matcher, context);
+    }
+
+    /**
+     * @deprecated Use {@link #tryAdvancedMatcher(String, TagContext)} and pass in the relevant context for where the matcher is being checked.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean tryAdvancedMatcher(String matcher) {
+        return tryAdvancedMatcher(matcher, Debug.currentContext != null ? Debug.currentContext : CoreUtilities.noDebugContext);
     }
 
     /**

--- a/src/main/java/com/denizenscript/denizencore/objects/ObjectTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/ObjectTag.java
@@ -259,7 +259,7 @@ public interface ObjectTag {
     /**
      * Used for objects to override, should not be called externally. Call 'tryAdvancedMatcher' instead.
      */
-    default boolean advancedMatches(String matcher) {
+    default boolean advancedMatches(String matcher, TagContext context) {
         return ScriptEvent.runGenericCheck(matcher, identify());
     }
 
@@ -267,7 +267,7 @@ public interface ObjectTag {
      * Returns whether this object matches the specified input using 'advanced matcher' logic.
      * Do not override.
      */
-    default boolean tryAdvancedMatcher(String matcher) {
+    default boolean tryAdvancedMatcher(String matcher, TagContext context) {
         if (CoreConfiguration.debugVerbose) {
             Debug.verboseLog("Trying advanced matcher '" + matcher + "' on object '" + identify() + "'");
         }
@@ -275,7 +275,7 @@ public interface ObjectTag {
             return false;
         }
         if (matcher.startsWith("!")) {
-            return !tryAdvancedMatcher(matcher.substring(1));
+            return !tryAdvancedMatcher(matcher.substring(1), context);
         }
         ObjectType<? extends ObjectTag> thisType = getDenizenObjectType();
         if (thisType != null && thisType.tagProcessor != null) {
@@ -287,7 +287,7 @@ public interface ObjectTag {
                 return result;
             }
         }
-        return advancedMatches(matcher);
+        return advancedMatches(matcher, context);
     }
 
     /**

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ElementTag.java
@@ -2533,7 +2533,7 @@ public class ElementTag implements ObjectTag {
         // - narrate <element[these characters have diacritics: éàç].unaccented>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "unaccented", (attribute, object) -> {
-            return new ElementTag(unaccentedPattern.matcher(Normalizer.normalize(object.asString(), Normalizer.Form.NFKD)).replaceAll(""), true);
+            return new ElementTag(UNACCENTED_PATTERN.matcher(Normalizer.normalize(object.asString(), Normalizer.Form.NFKD)).replaceAll(""), true);
         });
     }
 
@@ -2597,15 +2597,14 @@ public class ElementTag implements ObjectTag {
     }
 
     @Override
-    public boolean advancedMatches(String matcher) {
-        String matcherLow = CoreUtilities.toLowerCase(matcher);
-        switch (matcherLow) {
-            case "integer": return isInt();
-            case "decimal": return isDouble();
-            case "boolean": return isBoolean();
-        }
-        return ScriptEvent.runGenericCheck(matcher, element);
+    public boolean advancedMatches(String matcher, TagContext context) {
+        return switch (CoreUtilities.toLowerCase(matcher)) {
+            case "integer" -> isInt();
+            case "decimal" -> isDouble();
+            case "boolean" -> isBoolean();
+            default -> ScriptEvent.runGenericCheck(matcher, element);
+        };
     }
 
-    public static Pattern unaccentedPattern = Pattern.compile("[\\u0300-\\u036f]");
+    public static final Pattern UNACCENTED_PATTERN = Pattern.compile("[\\u0300-\\u036f]");
 }

--- a/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/ListTag.java
@@ -1644,7 +1644,7 @@ public class ListTag implements List<String>, ObjectTag {
             String matcher = matchText.asString();
             for (int i = 0; i < list.size(); i++) {
                 ObjectTag object = list.getObject(i);
-                if (object != null && object.tryAdvancedMatcher(matcher)) {
+                if (object != null && object.tryAdvancedMatcher(matcher, attribute.context)) {
                     positions.add(String.valueOf(i + 1));
                 }
             }
@@ -1706,7 +1706,7 @@ public class ListTag implements List<String>, ObjectTag {
         tagProcessor.registerStaticTag(ElementTag.class, ElementTag.class, "find_match", (attribute, list, matcher) -> {
             for (int i = 0; i < list.size(); i++) {
                 ObjectTag object = list.getObject(i);
-                if (object != null && object.tryAdvancedMatcher(matcher.asString())) {
+                if (object != null && object.tryAdvancedMatcher(matcher.asString(), attribute.context)) {
                     return new ElementTag(i + 1);
                 }
             }
@@ -1767,7 +1767,7 @@ public class ListTag implements List<String>, ObjectTag {
         tagProcessor.registerStaticTag(ElementTag.class, ElementTag.class, "count_matches", (attribute, list, matcher) -> {
             int count = 0;
             for (ObjectTag object : list.objectForms) {
-                if (object != null && object.tryAdvancedMatcher(matcher.asString())) {
+                if (object != null && object.tryAdvancedMatcher(matcher.asString(), attribute.context)) {
                     count++;
                 }
             }
@@ -2682,7 +2682,7 @@ public class ListTag implements List<String>, ObjectTag {
         tagProcessor.registerTag(ElementTag.class, ElementTag.class, "contains_match", (attribute, object, input) -> {
             String matcher = input.asString();
             for (ObjectTag objectTag : object.objectForms) {
-                if (objectTag.tryAdvancedMatcher(matcher)) {
+                if (objectTag.tryAdvancedMatcher(matcher, attribute.context)) {
                     return new ElementTag(true);
                 }
             }

--- a/src/main/java/com/denizenscript/denizencore/scripts/commands/Comparable.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/commands/Comparable.java
@@ -149,7 +149,7 @@ public class Comparable {
                 outcome = listContains(objB, objA, context);
                 break;
             case MATCHES:
-                outcome = objA.tryAdvancedMatcher(objB.toString());
+                outcome = objA.tryAdvancedMatcher(objB.toString(), context);
                 break;
             default:
                 // Impossible to reach

--- a/src/main/java/com/denizenscript/denizencore/tags/CoreObjectTags.java
+++ b/src/main/java/com/denizenscript/denizencore/tags/CoreObjectTags.java
@@ -268,7 +268,7 @@ public class CoreObjectTags {
             if (!attribute.hasParam()) {
                 return null;
             }
-            return new ElementTag(object.tryAdvancedMatcher(attribute.getParam()));
+            return new ElementTag(object.tryAdvancedMatcher(attribute.getParam(), attribute.context));
         }, "advanced_matches_text");
 
         // <--[tag]
@@ -278,10 +278,10 @@ public class CoreObjectTags {
         // Returns the reflected internal Java object for a given ObjectTag.
         // -->
         tagProcessor.registerTag(JavaReflectedObjectTag.class, "reflected_internal_object", (attribute, object) -> {
-            Object obj = object.getJavaObject();
             if (!CoreConfiguration.allowReflectionFieldReads) {
                 return null;
             }
+            Object obj = object.getJavaObject();
             if (obj == null) {
                 return null;
             }


### PR DESCRIPTION
## Changes

- `ScriptEvent#matchesScript` now sets `ScriptEvent$ScriptPath.context`.
- All `ObjectTag#tryAdvancedMatcher` calls now pass in the relevant context.
- `ObjectTag#tryAdvancedMatcher` and `#advancedMatches` now take in a `TagContext` parameter.
- (Unrelated) updated `ElementTag#advancedMatches` to modern `switch` expressions.
- (Unrelated) made `ElementTag.unaccentedPattern` a proper `final` constant.
- (Unreatled) Moved the `ObjectTag#getJavaObject` call in `ObjectTag.reflected_internal_object` to after the `allowReflectionFieldReads` check.

## Additions

- `ScriptEvent$ScriptPath.context` - stores the context from the current event being matched against it.

> [!NOTE]
> Not sure if the way I handled the context in `ScriptPath` is the best approach? thought that'd be better than passing it in normally to every `ScriptPath` method, but let me know what do you think.

> [!NOTE]
> Could include an `advancedMatches` overload that doesn't take a context or a `tryAdvancedMatcher` overload that passes in the global one, but the former is a really easy refactor in existing ones and not really that useful to new ones, and the latter isn't that useful imo, because ideally every usage should pass in the proper context - would make sense in terms of back-support though, not sure how much API compatibility if at all do we want to have for these sort of things.