### PR TITLE
Handle secrets file loading exceptions

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/core/SecretTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/SecretTag.java
@@ -10,6 +10,9 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionRefuse;
 import com.denizenscript.denizencore.utilities.YamlConfiguration;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
+import org.yaml.snakeyaml.error.Mark;
+import org.yaml.snakeyaml.error.MarkedYAMLException;
 
 import java.io.File;
 
@@ -28,7 +31,16 @@ public class SecretTag implements ObjectTag {
                 return;
             }
             fileContent = fileContent.substring("!SECRETS_FILE".length());
-            secretsFile = YamlConfiguration.load(fileContent);
+            try {
+                secretsFile = YamlConfiguration.load(fileContent);
+            }
+            catch (MarkedYAMLException mye) {
+                Mark problem = mye.getProblemMark();
+                Debug.echoError("Error occurred while loading secrets file, on line " + (problem.getLine() + 1) + ", column " + (problem.getColumn() + 1) + ": " + mye.getProblem());
+            }
+            catch (Exception e) {
+                Debug.echoError("Unknown error occurred while loading secrets file (" + DebugInternals.getClassNameOpti(e.getClass()) + "), hidden for security reasons; try deleting the secrets file to regenerate it.");
+            }
         }
         else {
             secretsFile = new YamlConfiguration();

--- a/src/main/java/com/denizenscript/denizencore/objects/core/SecretTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/SecretTag.java
@@ -38,9 +38,6 @@ public class SecretTag implements ObjectTag {
                 Mark problem = mye.getProblemMark();
                 Debug.echoError("Error occurred while loading secrets file, on line " + (problem.getLine() + 1) + ", column " + (problem.getColumn() + 1) + ": " + mye.getProblem());
             }
-            catch (Exception e) {
-                Debug.echoError("Unknown error occurred while loading secrets file (" + DebugInternals.getClassNameOpti(e.getClass()) + "), hidden for security reasons; try deleting the secrets file to regenerate it.");
-            }
         }
         else {
             secretsFile = new YamlConfiguration();

--- a/src/main/java/com/denizenscript/denizencore/objects/core/SecretTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/SecretTag.java
@@ -10,7 +10,6 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionRefuse;
 import com.denizenscript.denizencore.utilities.YamlConfiguration;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
 import org.yaml.snakeyaml.error.Mark;
 import org.yaml.snakeyaml.error.MarkedYAMLException;
 


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1280121230439223329).

## Changes

- `SecretTag#load` now has a `try/catch` around the `YamlConfiguration#load` call, to avoid printing exception with potential file content to console.
YAML exceptions now get formatted into a proper error message like so: `Error occurred while loading secrets file, on line 7, column 7: found character '@' that cannot start any token. (Do not use @ for indentation)`, and any other exceptions get formatted into an error message with the exception type.

> [!NOTE]
> The error message includes SnakeYAML "problem" string to so that the error can actually tell you what's wrong, which shouldn't ever include actual file information afaik, especially seeing as there's a different getter for that.

> [!NOTE]
> Not sure what do we want to do about other exceptions we can't specifically format - currently it just hides them and gives you the type because they could also include sensitive content, but that's not ideal.
> Maybe we should just add a separate config setting or some other security toggle?