### PR TITLE
`ObjectProperty#getTagValue`

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/properties/ObjectProperty.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/properties/ObjectProperty.java
@@ -10,6 +10,10 @@ public abstract class ObjectProperty<TObj extends ObjectTag, TData extends Objec
 
     public abstract TData getPropertyValue();
 
+    public TData getTagValue() {
+        return getPropertyValue();
+    }
+
     public boolean isDefaultValue(TData data) {
         return false;
     }
@@ -36,13 +40,13 @@ public abstract class ObjectProperty<TObj extends ObjectTag, TData extends Objec
 
     public static <TObj extends ObjectTag, TData extends ObjectTag, TProp extends ObjectProperty<TObj, TData>>
         void autoRegister(String name, Class<TProp> propClass, Class<TData> dataClass, boolean isStatic, String... deprecatedVariants) {
-        PropertyParser.registerTagInternal(propClass, dataClass, name, (attribute, prop) -> prop.getPropertyValue(), deprecatedVariants, isStatic);
+        PropertyParser.registerTagInternal(propClass, dataClass, name, (attribute, prop) -> prop.getTagValue(), deprecatedVariants, isStatic);
         PropertyParser.registerMechanism(propClass, dataClass, name, (prop, mechanism, param) -> prop.setPropertyValue(param, mechanism), deprecatedVariants);
     }
 
     public static <TObj extends ObjectTag, TData extends ObjectTag, TProp extends ObjectProperty<TObj, TData>>
         void autoRegisterNullable(String name, Class<TProp> propClass, Class<TData> dataClass, boolean isStatic, String... deprecatedVariants) {
-        PropertyParser.registerTagInternal(propClass, dataClass, name, (attribute, prop) -> prop.getPropertyValue(), deprecatedVariants, isStatic);
+        PropertyParser.registerTagInternal(propClass, dataClass, name, (attribute, prop) -> prop.getTagValue(), deprecatedVariants, isStatic);
         PropertyParser.registerMechanism(propClass, name, (prop, mechanism) -> {
             if (!mechanism.hasValue()) {
                 prop.setPropertyValue(null, mechanism);

--- a/src/main/java/com/denizenscript/denizencore/objects/properties/ObjectProperty.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/properties/ObjectProperty.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizencore.objects.properties;
 
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
 
 public abstract class ObjectProperty<TObj extends ObjectTag, TData extends ObjectTag> implements Property {
@@ -10,7 +11,7 @@ public abstract class ObjectProperty<TObj extends ObjectTag, TData extends Objec
 
     public abstract TData getPropertyValue();
 
-    public TData getTagValue() {
+    public TData getTagValue(Attribute attribute) {
         return getPropertyValue();
     }
 
@@ -40,13 +41,13 @@ public abstract class ObjectProperty<TObj extends ObjectTag, TData extends Objec
 
     public static <TObj extends ObjectTag, TData extends ObjectTag, TProp extends ObjectProperty<TObj, TData>>
         void autoRegister(String name, Class<TProp> propClass, Class<TData> dataClass, boolean isStatic, String... deprecatedVariants) {
-        PropertyParser.registerTagInternal(propClass, dataClass, name, (attribute, prop) -> prop.getTagValue(), deprecatedVariants, isStatic);
+        PropertyParser.registerTagInternal(propClass, dataClass, name, (attribute, prop) -> prop.getTagValue(attribute), deprecatedVariants, isStatic);
         PropertyParser.registerMechanism(propClass, dataClass, name, (prop, mechanism, param) -> prop.setPropertyValue(param, mechanism), deprecatedVariants);
     }
 
     public static <TObj extends ObjectTag, TData extends ObjectTag, TProp extends ObjectProperty<TObj, TData>>
         void autoRegisterNullable(String name, Class<TProp> propClass, Class<TData> dataClass, boolean isStatic, String... deprecatedVariants) {
-        PropertyParser.registerTagInternal(propClass, dataClass, name, (attribute, prop) -> prop.getTagValue(), deprecatedVariants, isStatic);
+        PropertyParser.registerTagInternal(propClass, dataClass, name, (attribute, prop) -> prop.getTagValue(attribute), deprecatedVariants, isStatic);
         PropertyParser.registerMechanism(propClass, name, (prop, mechanism) -> {
             if (!mechanism.hasValue()) {
                 prop.setPropertyValue(null, mechanism);


### PR DESCRIPTION
## Additions

- `ObjectProperty#getTagValue(Attribute)` - used in `autoRegister` so that you can have different tag returns and property values without having to manually register the tag and mech (returns `#getPropertyValue` by default).