### PR TITLE
Add util method for parsing `UUID`s

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/core/JavaReflectedObjectTag.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/core/JavaReflectedObjectTag.java
@@ -10,7 +10,9 @@ import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 public class JavaReflectedObjectTag implements ObjectTag {
@@ -50,13 +52,8 @@ public class JavaReflectedObjectTag implements ObjectTag {
             return null;
         }
         clearOldRefs();
-        try {
-            UUID uuid = UUID.fromString(id);
-            return persistedReferences.get(uuid);
-        }
-        catch (IllegalArgumentException ex) {
-            return null;
-        }
+        UUID uuid = CoreUtilities.tryParseUUID(id);
+        return uuid != null ? persistedReferences.get(uuid) : null;
     }
 
     public static boolean matches(String string) {

--- a/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
+++ b/src/main/java/com/denizenscript/denizencore/utilities/CoreUtilities.java
@@ -1,16 +1,21 @@
 package com.denizenscript.denizencore.utilities;
 
 import com.denizenscript.denizencore.DenizenCore;
-import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizencore.objects.core.*;
-import com.denizenscript.denizencore.scripts.ScriptBuilder;
-import com.denizenscript.denizencore.scripts.ScriptHelper;
-import com.denizenscript.denizencore.tags.TagManager;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.ArgumentHelper;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectFetcher;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.denizencore.scripts.ScriptBuilder;
+import com.denizenscript.denizencore.scripts.ScriptHelper;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.TagContext;
+import com.denizenscript.denizencore.tags.TagManager;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
 
 import java.io.*;
@@ -475,7 +480,7 @@ public class CoreUtilities {
 
     public static String concat(List<String> str, String split) {
         StringBuilder sb = new StringBuilder();
-        if (str.size() > 0) {
+        if (!str.isEmpty()) {
             sb.append(str.get(0));
         }
         for (int i = 1; i < str.size(); i++) {
@@ -597,6 +602,15 @@ public class CoreUtilities {
             }
         }
         return new String(data);
+    }
+
+    public static UUID tryParseUUID(String uuid) {
+        try {
+            return UUID.fromString(uuid);
+        }
+        catch (IllegalArgumentException ignored) {
+            return null;
+        }
     }
 
     public static String getXthArg(int argc, String args) {


### PR DESCRIPTION
Adds `CoreUtilities#tryParseUUID`, just a small util method to avoid having to `try/catch` in scenarios where all you really need is just a `UUID` or null.

> [!NOTE]
> `UUID#fromString` handles checking the string obviously, but could also do some separate initial checks like making sure all chars in the string are valid and such, lmk if you think that's needed.

> [!NOTE]
> Not sure if the name is great? could also maybe do `uuidFromString`.