### PR TITLE
Improve `ObjectProperty` overriding behavior

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/objects/properties/ObjectProperty.java
+++ b/src/main/java/com/denizenscript/denizencore/objects/properties/ObjectProperty.java
@@ -22,19 +22,19 @@ public abstract class ObjectProperty<TObj extends ObjectTag, TData extends Objec
     @Override
     public TData getPropertyValueNoDefault() {
         TData res = getPropertyValue();
-        return res == null || isDefaultValue(res) ? null : getPropertyValue();
+        return res == null || isDefaultValue(res) ? null : res;
     }
 
     @Override
     public String getPropertySavableValue() {
-        TData res = getPropertyValue();
-        return res == null || isDefaultValue(res) ? null : getPropertyValue().savable();
+        TData res = getPropertyValueNoDefault();
+        return res == null ? null : res.savable();
     }
 
     @Deprecated @Override
     public String getPropertyString() {
-        TData res = getPropertyValue();
-        return res == null || isDefaultValue(res) ? null : getPropertyValue().identify();
+        TData res = getPropertyValueNoDefault();
+        return res == null ? null : res.identify();
     }
 
     public abstract void setPropertyValue(TData data, Mechanism mechanism);


### PR DESCRIPTION
Currently a couple of `ObjectProperty` methods re-implement the `isDefaultValue` logic, meaning overriding `getPropertyValueNoDefault` doesn't actually change them.
This makes these methods use `getPropertyValueNoDefault`, letting you override `getPropertyValueNoDefault` with custom checking logic.

Also removes the weird behavior where it would call `getPropertyValue` twice, not sure if there's any hidden reason for that I missed?