### PR TITLE
Script formats improvements & fixes

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/scripts/ScriptFormattingContext.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/ScriptFormattingContext.java
@@ -18,12 +18,12 @@ import java.util.Set;
 public record ScriptFormattingContext(Map<String, ParseableTag> formats, ParseableTag singleFormat) {
     
     // <--[language]
-    // @name Script Logging Format
+    // @name Script Formats
     // @group Script Container System
     // @description
-    // Script logging contexts provide the format certain commands will use for their texts. Most notably, this includes <@link command debug>.
+    // Script formats provide the formats certain commands within that script will use for their texts. Most notably, this includes <@link command debug>.
     // See specific command's documentation for information on which formats they use (for example, the 'debug' command supports a 'debug' format and an 'error' format).
-    // The formats are specified under a 'formats' key, and can be either a <@link language Format Script Containers> or a direct format with the same syntax as format scripts.
+    // The formats are specified under a 'formats' key, and can be either <@link language Format Script Containers> or a direct format with the same syntax as format scripts.
     // When specifying a direct format, use the format name as the key; When specifying a format script, use '<format>_script' as the key (see example below).
     // <code>
     // my_project_task:

--- a/src/main/java/com/denizenscript/denizencore/scripts/commands/core/DebugCommand.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/commands/core/DebugCommand.java
@@ -15,8 +15,8 @@ import com.denizenscript.denizencore.utilities.debugging.DebugSubmitter;
 
 public class DebugCommand extends AbstractCommand implements Holdable {
 
-    public static final String DEBUG_FORMAT = ScriptFormattingContext.registerFormatType("debug");
-    public static final String ERROR_FORMAT = ScriptFormattingContext.registerFormatType("error");
+    public static final String DEBUG_FORMAT_TYPE = ScriptFormattingContext.registerFormatType("debug");
+    public static final String ERROR_FORMAT_TYPE = ScriptFormattingContext.registerFormatType("error");
 
     public DebugCommand() {
         setName("debug");
@@ -118,7 +118,7 @@ public class DebugCommand extends AbstractCommand implements Holdable {
             scriptEntry.setFinished(true);
         }
         switch (dbType) {
-            case OUTPUT -> Debug.echoDebug(null, formattingContext == null ? debug : formattingContext.format(DEBUG_FORMAT, debug, scriptEntry));
+            case OUTPUT -> Debug.echoDebug(null, formattingContext == null ? debug : formattingContext.format(DEBUG_FORMAT_TYPE, debug, scriptEntry));
             case DEBUG -> Debug.echoDebug(scriptEntry, debug);
             case HEADER -> Debug.echoDebug(scriptEntry, Debug.DebugElement.Header, debug);
             case FOOTER -> Debug.echoDebug(scriptEntry, Debug.DebugElement.Footer, debug);
@@ -126,7 +126,7 @@ public class DebugCommand extends AbstractCommand implements Holdable {
             case LOG -> Debug.log(name, debug);
             case APPROVAL -> Debug.echoApproval(debug);
             case ERROR -> {
-                String formatted = formattingContext != null ? formattingContext.formatOrNull(ERROR_FORMAT, debug, scriptEntry) : null;
+                String formatted = formattingContext != null ? formattingContext.formatOrNull(ERROR_FORMAT_TYPE, debug, scriptEntry) : null;
                 if (formatted != null) {
                     Debug.echoDebug(null, formatted);
                 }

--- a/src/main/java/com/denizenscript/denizencore/scripts/commands/core/DebugCommand.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/commands/core/DebugCommand.java
@@ -39,7 +39,7 @@ public class DebugCommand extends AbstractCommand implements Holdable {
     // @Description
     // Use to quickly output debug information to console.
     //
-    // Outputs plain text debug to the console by default, supporting the 'debug' format type (see <@link language Script Logging Formats>).
+    // Outputs plain text debug to the console by default, supporting the 'debug' format type (see <@link language Script Formats>).
     //
     // Alternatively, specify one of the following debug types:
     // DEBUG: standard hideable debug.
@@ -48,7 +48,7 @@ public class DebugCommand extends AbstractCommand implements Holdable {
     // SPACER: a spacer line.
     // LOG: global output, non-hideable.
     // APPROVAL: "Okay!" output, non-hideable.
-    // ERROR: "Error!" output, non-hideable. Supports the 'error' format type, see <@link language Script Logging Formats>.
+    // ERROR: "Error!" output, non-hideable. Supports the 'error' format type, see <@link language Script Formats>.
     // REPORT: normally used to describe the arguments of a command, requires a name, hideable.
     // EXCEPTION: outputs a full java stacktrace.
     // RECORD: Use message 'start' to start recording, 'submit' to submit a recording, or 'cancel' to cancel a recording.

--- a/src/main/java/com/denizenscript/denizencore/scripts/containers/ScriptContainer.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/containers/ScriptContainer.java
@@ -75,7 +75,6 @@ public class ScriptContainer implements Debuggable {
         configurationSection.forceLoweredRootKey("speed");
         configurationSection.forceLoweredRootKey("enabled");
         this.name = CoreUtilities.toUpperCase(scriptContainerName);
-        this.formattingContext = ScriptFormattingContext.parseFromConfiguration(this);
     }
 
     public <T extends ObjectTag> T tagObject(String text, Class<T> type) {
@@ -107,6 +106,7 @@ public class ScriptContainer implements Debuggable {
     }
 
     public void postCheck() {
+        this.formattingContext = ScriptFormattingContext.parseFromConfiguration(this);
     }
 
     public ScriptFormattingContext getFormattingContext() {

--- a/src/main/java/com/denizenscript/denizencore/scripts/containers/core/ProcedureScriptContainer.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/containers/core/ProcedureScriptContainer.java
@@ -58,6 +58,7 @@ public class ProcedureScriptContainer extends ScriptContainer {
 
     @Override
     public void postCheck() {
+        super.postCheck();
         // Trigger load + cache
         if (shouldEnable() && contains("script")) {
             getBaseEntries(DenizenCore.implementation.getEmptyScriptEntryData());

--- a/src/main/java/com/denizenscript/denizencore/scripts/containers/core/TaskScriptContainer.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/containers/core/TaskScriptContainer.java
@@ -47,6 +47,7 @@ public class TaskScriptContainer extends ScriptContainer {
 
     @Override
     public void postCheck() {
+        super.postCheck();
         // Trigger load + cache
         if (shouldEnable() && contains("script")) {
             getBaseEntries(DenizenCore.implementation.getEmptyScriptEntryData());


### PR DESCRIPTION
Just a couple of fixes for #115.
- Renames the `Script Logging Format` lang meta to just `Script Formats` - open to feedback on the name, but the old one didn't really fit because it's not necessarily logging specific.
- Moved the formatting context loading in `ScriptContainer` to `postCheck`, so that it's handled after all format scripts that may be referenced there are loaded (similarly to how tasks and procs load & cache their script section there).